### PR TITLE
Add Result

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,12 @@
 cmake_minimum_required(VERSION 3.14)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
+set(CMAKE_CXX_STANDARD 17)
 
 project(result)
+
+add_library(result INTERFACE)
+target_include_directories(result INTERFACE include)
 
 if(BUILD_TESTING)
   enable_testing()
@@ -11,6 +15,6 @@ if(BUILD_TESTING)
   find_package(Catch2 REQUIRED)
 
   add_executable(result_test test/result_test.cpp)
-  target_link_libraries(result_test PRIVATE Catch2::Catch2WithMain)
+  target_link_libraries(result_test PRIVATE result Catch2::Catch2WithMain)
   catch_discover_tests(result_test)
 endif()

--- a/include/result/internal/err_msg.hpp
+++ b/include/result/internal/err_msg.hpp
@@ -7,4 +7,6 @@ namespace res::internal {
 
 using ErrMsg = std::string;
 using ErrMsgPtr = std::shared_ptr<ErrMsg>;
+
+ErrMsgPtr uninitialized_err_msg_ptr = std::make_shared<ErrMsg>("result is uninitialized");
 }

--- a/include/result/internal/err_msg.hpp
+++ b/include/result/internal/err_msg.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace res::internal {
+
+using ErrMsg = std::string;
+using ErrMsgPtr = std::shared_ptr<ErrMsg>;
+}

--- a/include/result/internal/error.hpp
+++ b/include/result/internal/error.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <exception>
+
+namespace res::internal {
+
+using Error = std::exception;
+}

--- a/include/result/internal/error.hpp
+++ b/include/result/internal/error.hpp
@@ -1,8 +1,0 @@
-#pragma once
-
-#include <exception>
-
-namespace res::internal {
-
-using Error = std::exception;
-}

--- a/include/result/internal/ok.hpp
+++ b/include/result/internal/ok.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace res {
+
+namespace internal { struct Ok {}; }
+constexpr internal::Ok ok = {};
+}

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -2,16 +2,16 @@
 
 #include "internal/ok.hpp"
 #include <optional>
+#include <exception>
 
 namespace res {
 
-template<typename E>
 class Result {
  private:
-  std::optional<E> error;
+  std::optional<std::exception> error;
  public:
-  Result(const E& err) : error(err) {}
   Result(const internal::Ok& ok) {}
+  Result(const std::exception& err) : error(err) {}
   bool is_ok() const { return !error.has_value(); }
   bool is_err() const { return error.has_value(); }
 };

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -9,19 +9,19 @@ namespace res {
 
 class Result {
  private:
-  std::optional<std::string> error;
+  std::optional<std::string> opt_err_msg;
  public:
   Result(const internal::Ok& ok) {}
 
   template<typename U>
-  Result(const U& err) : error(err) {}
+  Result(const U& err_msg) : opt_err_msg(err_msg) {}
 
-  bool is_ok() const { return !error.has_value(); }
-  bool is_err() const { return error.has_value(); }
+  bool is_ok() const { return !opt_err_msg.has_value(); }
+  bool is_err() const { return opt_err_msg.has_value(); }
 
   std::string unwrap_err() const {
-    if (is_ok()) throw std::runtime_error("is ok");
-    return error.value();
+    if (!opt_err_msg.has_value()) throw std::runtime_error("is ok");
+    return opt_err_msg.value();
   }
 };
 }

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -11,7 +11,7 @@ class Result {
  private:
   internal::ErrMsgPtr err_msg_ptr;
  public:
-  Result() {}
+  Result() : err_msg_ptr(internal::uninitialized_err_msg_ptr) {}
   Result(const internal::Ok& ok) {}
   Result(const internal::ErrMsgPtr& err_msg_ptr) : err_msg_ptr(err_msg_ptr) {}
 

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -1,27 +1,28 @@
 #pragma once
 
+#include "internal/err_msg.hpp"
 #include "internal/ok.hpp"
 #include <exception>
-#include <optional>
-#include <string>
+#include <memory>
 
 namespace res {
 
 class Result {
  private:
-  std::optional<std::string> opt_err_msg;
+  internal::ErrMsgPtr err_msg_ptr;
  public:
   Result(const internal::Ok& ok) {}
+  Result(const internal::ErrMsgPtr& err_msg_ptr) : err_msg_ptr(err_msg_ptr) {}
 
-  template<typename U>
-  Result(const U& err_msg) : opt_err_msg(err_msg) {}
+  template<typename E>
+  Result(const E& err_msg) : err_msg_ptr(std::make_shared<internal::ErrMsg>(err_msg)) {}
 
-  bool is_ok() const { return !opt_err_msg.has_value(); }
-  bool is_err() const { return opt_err_msg.has_value(); }
+  bool is_ok() const { return !err_msg_ptr; }
+  bool is_err() const { return (bool)err_msg_ptr; }
 
-  std::string unwrap_err() const {
-    if (!opt_err_msg.has_value()) throw std::runtime_error("is ok");
-    return opt_err_msg.value();
+  internal::ErrMsg unwrap_err() const {
+    if (!err_msg_ptr) throw std::runtime_error("is ok");
+    return *err_msg_ptr;
   }
 };
 }

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -11,6 +11,7 @@ class Result {
  private:
   internal::ErrMsgPtr err_msg_ptr;
  public:
+  Result() {}
   Result(const internal::Ok& ok) {}
   Result(const internal::ErrMsgPtr& err_msg_ptr) : err_msg_ptr(err_msg_ptr) {}
 

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "internal/error.hpp"
 #include "internal/ok.hpp"
 #include <optional>
 #include <exception>
@@ -8,10 +9,10 @@ namespace res {
 
 class Result {
  private:
-  std::optional<std::exception> error;
+  std::optional<internal::Error> error;
  public:
   Result(const internal::Ok& ok) {}
-  Result(const std::exception& err) : error(err) {}
+  Result(const internal::Error& err) : error(err) {}
   bool is_ok() const { return !error.has_value(); }
   bool is_err() const { return error.has_value(); }
 };

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -24,6 +24,6 @@ class Result {
   internal::ErrMsg unwrap_err() const {
     if (!err_msg_ptr) throw std::runtime_error("is ok");
     return *err_msg_ptr;
-  }
+  }  // LCOV_EXCL_LINE
 };
 }

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "internal/ok.hpp"
+#include <optional>
+
+namespace res {
+
+template<typename E>
+class Result {
+ private:
+  std::optional<E> error;
+ public:
+  Result(const E& err) : error(err) {}
+  Result(const internal::Ok& ok) {}
+  bool is_ok() const { return !error.has_value(); }
+  bool is_err() const { return error.has_value(); }
+};
+}

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -1,18 +1,20 @@
 #pragma once
 
-#include "internal/error.hpp"
 #include "internal/ok.hpp"
 #include <optional>
-#include <exception>
+#include <string>
 
 namespace res {
 
 class Result {
  private:
-  std::optional<internal::Error> error;
+  std::optional<std::string> error;
  public:
   Result(const internal::Ok& ok) {}
-  Result(const internal::Error& err) : error(err) {}
+
+  template<typename U>
+  Result(const U& err) : error(err) {}
+
   bool is_ok() const { return !error.has_value(); }
   bool is_err() const { return error.has_value(); }
 };

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "internal/ok.hpp"
+#include <exception>
 #include <optional>
 #include <string>
 
@@ -17,5 +18,10 @@ class Result {
 
   bool is_ok() const { return !error.has_value(); }
   bool is_err() const { return error.has_value(); }
+
+  std::string unwrap_err() const {
+    if (is_ok()) throw std::runtime_error("is ok");
+    return error.value();
+  }
 };
 }

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -15,13 +15,13 @@ TEST_CASE("check error result") {
 
 TEST_CASE("call `unwrap_err` on error result") {
   const res::internal::ErrMsg err_msg = "unknown error";
-  res::Result res = err_msg;
+  const res::Result res = err_msg;
   REQUIRE(res.is_err());
   REQUIRE(res.unwrap_err() == err_msg);
 }
 
 TEST_CASE("call `unwrap_err` on ok result") {
-  res::Result res = res::ok;
+  const res::Result res = res::ok;
   REQUIRE(res.is_ok());
   REQUIRE_THROWS(res.unwrap_err());
 }
@@ -40,5 +40,23 @@ TEST_CASE("get result from function returning ok") {
 
 TEST_CASE("get result from function returning error") {
   const auto res = foo(false);
+  REQUIRE(res.is_err());
+}
+
+TEST_CASE("check if ok result is preserved outside the scope") {
+  res::Result res;
+  {
+    res = foo(true);
+    REQUIRE(res.is_ok());
+  }
+  REQUIRE(res.is_ok());
+}
+
+TEST_CASE("check if error result is preserved outside the scope") {
+  res::Result res;
+  {
+    res = foo(false);
+    REQUIRE(res.is_err());
+  }
   REQUIRE(res.is_err());
 }

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -1,5 +1,15 @@
+#include <result/result.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <string>
 
-TEST_CASE("example test") {
-  REQUIRE(true);
+TEST_CASE("ok test") {
+  res::Result<std::string> res = res::ok;
+  REQUIRE(res.is_ok());
+  REQUIRE_FALSE(res.is_err());
+}
+
+TEST_CASE("err test") {
+  res::Result<std::string> res = std::string("unknown error");
+  REQUIRE(res.is_err());
+  REQUIRE_FALSE(res.is_ok());
 }

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -1,15 +1,27 @@
 #include <result/result.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <string>
 
-TEST_CASE("ok test") {
-  res::Result res = res::ok;
+TEST_CASE("check ok result") {
+  const res::Result res = res::ok;
   REQUIRE(res.is_ok());
   REQUIRE_FALSE(res.is_err());
 }
 
-TEST_CASE("err test") {
-  res::Result res = "unknown error";
+TEST_CASE("check error result") {
+  const res::Result res = "unknown error";
   REQUIRE(res.is_err());
   REQUIRE_FALSE(res.is_ok());
+}
+
+TEST_CASE("call `unwrap_err` on error result") {
+  const std::string err_msg = "unknown error";
+  res::Result res = err_msg;
+  REQUIRE(res.is_err());
+  REQUIRE(res.unwrap_err() == err_msg);
+}
+
+TEST_CASE("call `unwrap_err` on ok result") {
+  res::Result res = res::ok;
+  REQUIRE(res.is_ok());
+  REQUIRE_THROWS(res.unwrap_err());
 }

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -9,7 +9,7 @@ TEST_CASE("ok test") {
 }
 
 TEST_CASE("err test") {
-  res::Result res = std::runtime_error("example");
+  res::Result res = "unknown error";
   REQUIRE(res.is_err());
   REQUIRE_FALSE(res.is_ok());
 }

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -3,13 +3,13 @@
 #include <string>
 
 TEST_CASE("ok test") {
-  res::Result<std::string> res = res::ok;
+  res::Result res = res::ok;
   REQUIRE(res.is_ok());
   REQUIRE_FALSE(res.is_err());
 }
 
 TEST_CASE("err test") {
-  res::Result<std::string> res = std::string("unknown error");
+  res::Result res = std::runtime_error("example");
   REQUIRE(res.is_err());
   REQUIRE_FALSE(res.is_ok());
 }

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -14,7 +14,7 @@ TEST_CASE("check error result") {
 }
 
 TEST_CASE("call `unwrap_err` on error result") {
-  const std::string err_msg = "unknown error";
+  const res::internal::ErrMsg err_msg = "unknown error";
   res::Result res = err_msg;
   REQUIRE(res.is_err());
   REQUIRE(res.unwrap_err() == err_msg);

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -25,3 +25,20 @@ TEST_CASE("call `unwrap_err` on ok result") {
   REQUIRE(res.is_ok());
   REQUIRE_THROWS(res.unwrap_err());
 }
+
+namespace {
+res::Result foo(bool is_ok) {
+  if (is_ok) return res::ok;
+  return "unknown error";
+}
+}
+
+TEST_CASE("get result from function returning ok") {
+  const auto res = foo(true);
+  REQUIRE(res.is_ok());
+}
+
+TEST_CASE("get result from function returning error") {
+  const auto res = foo(false);
+  REQUIRE(res.is_err());
+}

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -13,6 +13,11 @@ TEST_CASE("check error result") {
   REQUIRE_FALSE(res.is_ok());
 }
 
+TEST_CASE("uninitialized result contains error") {
+  const res::Result res;
+  REQUIRE(res.is_err());
+}
+
 TEST_CASE("call `unwrap_err` on error result") {
   const res::internal::ErrMsg err_msg = "unknown error";
   const res::Result res = err_msg;

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -31,6 +31,20 @@ TEST_CASE("call `unwrap_err` on ok result") {
   REQUIRE_THROWS(res.unwrap_err());
 }
 
+TEST_CASE("check rewriting result") {
+  res::Result res = res::ok;
+  REQUIRE(res.is_ok());
+  res::internal::ErrMsg err_msg = "unknown error";
+  res = err_msg;
+  REQUIRE(res.is_err());
+  REQUIRE(res.unwrap_err() == err_msg);
+  res = err_msg = "other error";
+  REQUIRE(res.is_err());
+  REQUIRE(res.unwrap_err() == err_msg);
+  res = res::ok;
+  REQUIRE(res.is_ok());
+}
+
 namespace {
 res::Result foo(bool is_ok) {
   if (is_ok) return res::ok;


### PR DESCRIPTION
add `res::Result` that contains:
- check if is contains ok or error.
- unwrapping error.

error is saved as `std::shared_ptr<std::string>`, using string for simplicity and using pointer to prevent deep copy.
result contains error if is uninitialized.