### PR TITLE
Modify C++ Compiler Flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         run: pip3 install cmake-format
 
       - name: Configure CMake
-        run: cmake . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G Ninja -DBUILD_TESTING=ON
+        run: cmake . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G Ninja -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS='-Werror'
 
       - name: Check code formatting
         run: cmake --build build --target check-format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,10 @@ target_include_directories(result INTERFACE include)
 
 if(BUILD_TESTING)
   enable_testing()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -coverage -g -O0")
 
   find_package(Catch2 REQUIRED)
 
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
   add_executable(result_test test/result_test.cpp test/result_or_test.cpp)
   target_link_libraries(result_test PRIVATE result Catch2::Catch2WithMain)
   catch_discover_tests(result_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic")
 
 project(result)
 

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -14,7 +14,7 @@ class Result {
 
  public:
   Result() : Result(Err("result is uninitialized")) {}
-  Result(const Ok& ok) {}
+  Result(const Ok&) {}
   Result(const Err& err) : err_opt(err) {}
 
   bool is_ok() const { return !err_opt.has_value(); }


### PR DESCRIPTION
- Modify C++ compiler flags for coverage.
- Add C++ compiler flags that enable warning.
- Treat warning as error on the build workflow during test job.