### PR TITLE
Add Type Casting

### DIFF
--- a/include/result/result_or.hpp
+++ b/include/result/result_or.hpp
@@ -4,6 +4,7 @@
 #include <variant>
 
 #include "err.hpp"
+#include "result.hpp"
 
 namespace res {
 
@@ -17,6 +18,11 @@ class ResultOr {
   ResultOr() : ResultOr(Err("result-or is uninitialized")) {}
   ResultOr(const T& data) : data(data), data_is_err(false) {}
   ResultOr(const Err& err) : data(err), data_is_err(true) {}
+
+  operator Result() const {
+    if (data_is_err) return std::get<Err>(data);
+    return Ok();
+  }
 
   bool is_ok() const { return !data_is_err; }
   bool is_err() const { return data_is_err; }

--- a/include/result/result_or.hpp
+++ b/include/result/result_or.hpp
@@ -20,9 +20,9 @@ class ResultOr {
   ResultOr(const Err& err) : data(err), data_is_err(true) {}
 
   template <typename U>
-  operator ResultOr<U>() const {
+  explicit operator ResultOr<U>() const {
     if (data_is_err) return std::get<Err>(data);
-    return std::get<T>(data);
+    return static_cast<U>(std::get<T>(data));
   }
 
   operator Result() const {

--- a/include/result/result_or.hpp
+++ b/include/result/result_or.hpp
@@ -19,6 +19,12 @@ class ResultOr {
   ResultOr(const T& data) : data(data), data_is_err(false) {}
   ResultOr(const Err& err) : data(err), data_is_err(true) {}
 
+  template <typename U>
+  operator ResultOr<U>() const {
+    if (data_is_err) return std::get<Err>(data);
+    return std::get<T>(data);
+  }
+
   operator Result() const {
     if (data_is_err) return std::get<Err>(data);
     return Ok();

--- a/include/result/result_or.hpp
+++ b/include/result/result_or.hpp
@@ -30,6 +30,12 @@ class ResultOr {
     return Ok();
   }
 
+  template <typename U>
+  ResultOr<U> as() const {
+    if (data_is_err) return std::get<Err>(data);
+    return static_cast<U>(std::get<T>(data));
+  }
+
   bool is_ok() const { return !data_is_err; }
   bool is_err() const { return data_is_err; }
 

--- a/test/result_or_test.cpp
+++ b/test/result_or_test.cpp
@@ -130,3 +130,20 @@ TEST_CASE("cast result-or into other result-or with different type") {
   REQUIRE(res.is_ok());
   REQUIRE(res.unwrap() == src.unwrap().data);
 }
+
+TEST_CASE("cast result-or into other result-or using `as()` function") {
+  res::ResultOr<Int> src;
+  res::ResultOr<int> res;
+  SECTION("from error result-or") {
+    src = res::Err("unknown error");
+    res = src.as<int>();
+    REQUIRE(res.is_err());
+    REQUIRE(res.unwrap_err() == src.unwrap_err());
+  }
+  SECTION("from ok result-or") {
+    src = Int{32};
+    res = src.as<int>();
+    REQUIRE(res.is_ok());
+    REQUIRE(res.unwrap() == src.unwrap().data);
+  }
+}

--- a/test/result_or_test.cpp
+++ b/test/result_or_test.cpp
@@ -124,7 +124,7 @@ TEST_CASE("cast result-or into other result-or with different type") {
   res::ResultOr<int> res = static_cast<res::ResultOr<int>>(src);
   REQUIRE(src.is_err());
   REQUIRE(res.is_err());
-  src = Int{.data = 32};
+  src = Int{32};
   res = static_cast<res::ResultOr<int>>(src);
   REQUIRE(src.is_ok());
   REQUIRE(res.is_ok());

--- a/test/result_or_test.cpp
+++ b/test/result_or_test.cpp
@@ -112,14 +112,21 @@ TEST_CASE("cast result-or into result") {
   REQUIRE(int_res.is_ok());
 }
 
+namespace {
+struct Int {
+  int data;
+  explicit operator int() const { return data; }
+};
+}  // namespace
+
 TEST_CASE("cast result-or into other result-or with different type") {
-  res::ResultOr<int> i_res;
-  res::ResultOr<float> f_res = i_res;
-  REQUIRE(f_res.is_err());
-  REQUIRE(i_res.is_err());
-  i_res = 32;
-  f_res = i_res;
-  REQUIRE(i_res.is_ok());
-  REQUIRE(f_res.is_ok());
-  REQUIRE(i_res.unwrap() == f_res.unwrap());
+  res::ResultOr<Int> src;
+  res::ResultOr<int> res = static_cast<res::ResultOr<int>>(src);
+  REQUIRE(src.is_err());
+  REQUIRE(res.is_err());
+  src = Int{.data = 32};
+  res = static_cast<res::ResultOr<int>>(src);
+  REQUIRE(src.is_ok());
+  REQUIRE(res.is_ok());
+  REQUIRE(res.unwrap() == src.unwrap().data);
 }

--- a/test/result_or_test.cpp
+++ b/test/result_or_test.cpp
@@ -121,29 +121,23 @@ struct Int {
 
 TEST_CASE("cast result-or into other result-or with different type") {
   res::ResultOr<Int> src;
-  res::ResultOr<int> res = static_cast<res::ResultOr<int>>(src);
-  REQUIRE(src.is_err());
-  REQUIRE(res.is_err());
-  src = Int{32};
-  res = static_cast<res::ResultOr<int>>(src);
-  REQUIRE(src.is_ok());
-  REQUIRE(res.is_ok());
-  REQUIRE(res.unwrap() == src.unwrap().data);
-}
-
-TEST_CASE("cast result-or into other result-or using `as()` function") {
-  res::ResultOr<Int> src;
   res::ResultOr<int> res;
-  SECTION("from error result-or") {
-    src = res::Err("unknown error");
-    res = src.as<int>();
-    REQUIRE(res.is_err());
-    REQUIRE(res.unwrap_err() == src.unwrap_err());
-  }
   SECTION("from ok result-or") {
     src = Int{32};
-    res = src.as<int>();
-    REQUIRE(res.is_ok());
-    REQUIRE(res.unwrap() == src.unwrap().data);
+    SECTION("using `as()` function") { res = src.as<int>(); }
+    SECTION("using explicit cast") {
+      res = static_cast<res::ResultOr<int>>(src);
+    }
+    CHECK(res.is_ok());
+    if (res.is_ok()) CHECK(res.unwrap() == src.unwrap().data);
+  }
+  SECTION("from error result-or") {
+    src = res::Err("unknown error");
+    SECTION("using `as()` function") { res = src.as<int>(); }
+    SECTION("using explicit cast") {
+      res = static_cast<res::ResultOr<int>>(src);
+    }
+    CHECK(res.is_err());
+    if (res.is_err()) CHECK(res.unwrap_err() == src.unwrap_err());
   }
 }

--- a/test/result_or_test.cpp
+++ b/test/result_or_test.cpp
@@ -103,13 +103,16 @@ TEST_CASE("check if error result-or is preserved outside the scope") {
 }
 
 TEST_CASE("cast result-or into result") {
-  res::ResultOr<int> int_res;
-  res::Result res = int_res;
-  REQUIRE(res.is_err());
-  REQUIRE(int_res.is_err());
-  res = int_res = 32;
-  REQUIRE(res.is_ok());
-  REQUIRE(int_res.is_ok());
+  res::ResultOr<int> src;
+  SECTION("from ok result-or") {
+    res::Result res = src = 32;
+    CHECK(res.is_ok());
+  }
+  SECTION("from error result-or") {
+    res::Result res = src = res::Err("unknown error");
+    CHECK(res.is_err());
+    if (res.is_err()) CHECK(res.unwrap_err() == src.unwrap_err());
+  }
 }
 
 namespace {
@@ -120,10 +123,9 @@ struct Int {
 }  // namespace
 
 TEST_CASE("cast result-or into other result-or with different type") {
-  res::ResultOr<Int> src;
   res::ResultOr<int> res;
   SECTION("from ok result-or") {
-    src = Int{32};
+    res::ResultOr<Int> src = Int{32};
     SECTION("using `as()` function") { res = src.as<int>(); }
     SECTION("using explicit cast") {
       res = static_cast<res::ResultOr<int>>(src);
@@ -132,7 +134,7 @@ TEST_CASE("cast result-or into other result-or with different type") {
     if (res.is_ok()) CHECK(res.unwrap() == src.unwrap().data);
   }
   SECTION("from error result-or") {
-    src = res::Err("unknown error");
+    res::ResultOr<Int> src = res::Err("unknown error");
     SECTION("using `as()` function") { res = src.as<int>(); }
     SECTION("using explicit cast") {
       res = static_cast<res::ResultOr<int>>(src);

--- a/test/result_or_test.cpp
+++ b/test/result_or_test.cpp
@@ -111,3 +111,15 @@ TEST_CASE("cast result-or into result") {
   REQUIRE(res.is_ok());
   REQUIRE(int_res.is_ok());
 }
+
+TEST_CASE("cast result-or into other result-or with different type") {
+  res::ResultOr<int> i_res;
+  res::ResultOr<float> f_res = i_res;
+  REQUIRE(f_res.is_err());
+  REQUIRE(i_res.is_err());
+  i_res = 32;
+  f_res = i_res;
+  REQUIRE(i_res.is_ok());
+  REQUIRE(f_res.is_ok());
+  REQUIRE(i_res.unwrap() == f_res.unwrap());
+}

--- a/test/result_or_test.cpp
+++ b/test/result_or_test.cpp
@@ -101,3 +101,13 @@ TEST_CASE("check if error result-or is preserved outside the scope") {
   REQUIRE(res.is_err());
   REQUIRE(res.unwrap_err() == std::string("unknown error"));
 }
+
+TEST_CASE("cast result-or into result") {
+  res::ResultOr<int> int_res;
+  res::Result res = int_res;
+  REQUIRE(res.is_err());
+  REQUIRE(int_res.is_err());
+  res = int_res = 32;
+  REQUIRE(res.is_ok());
+  REQUIRE(int_res.is_ok());
+}


### PR DESCRIPTION
- Add implicit type cast from `res::ResultOr` into `res::Result`.
- Add explicit type cast from `res::ResultOr` into another `res::ResultOr` with different type.
  - Add `as()` function to simplify this type cast.