### PR TITLE
Rename `res::ResultOr` into `res::ResultOf`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(BUILD_TESTING)
   include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
 
-  add_executable(result_test test/result_test.cpp test/result_or_test.cpp)
+  add_executable(result_test test/result_test.cpp test/result_of_test.cpp)
   target_link_libraries(result_test PRIVATE result Catch2::Catch2WithMain)
   catch_discover_tests(result_test)
 endif()

--- a/include/result/result_of.hpp
+++ b/include/result/result_of.hpp
@@ -9,18 +9,18 @@
 namespace res {
 
 template <typename T>
-class ResultOr {
+class ResultOf {
  private:
   std::variant<T, Err> data;
   bool data_is_err;
 
  public:
-  ResultOr() : ResultOr(Err("result-or is uninitialized")) {}
-  ResultOr(const T& data) : data(data), data_is_err(false) {}
-  ResultOr(const Err& err) : data(err), data_is_err(true) {}
+  ResultOf() : ResultOf(Err("result-of is uninitialized")) {}
+  ResultOf(const T& data) : data(data), data_is_err(false) {}
+  ResultOf(const Err& err) : data(err), data_is_err(true) {}
 
   template <typename U>
-  explicit operator ResultOr<U>() const {
+  explicit operator ResultOf<U>() const {
     if (data_is_err) return std::get<Err>(data);
     return static_cast<U>(std::get<T>(data));
   }
@@ -31,7 +31,7 @@ class ResultOr {
   }
 
   template <typename U>
-  ResultOr<U> as() const {
+  ResultOf<U> as() const {
     if (data_is_err) return std::get<Err>(data);
     return static_cast<U>(std::get<T>(data));
   }
@@ -41,13 +41,13 @@ class ResultOr {
 
   const T& unwrap() const {
     if (data_is_err)
-      throw std::runtime_error("unable to unwrap content of error result-or");
+      throw std::runtime_error("unable to unwrap content of error result-of");
     return std::get<T>(data);
   }
 
   const Err& unwrap_err() const {
     if (!data_is_err)
-      throw std::runtime_error("unable to unwrap error of ok result-or");
+      throw std::runtime_error("unable to unwrap error of ok result-of");
     return std::get<Err>(data);
   }
 };

--- a/test/result_of_test.cpp
+++ b/test/result_of_test.cpp
@@ -1,50 +1,50 @@
 #include <catch2/catch_test_macros.hpp>
-#include <result/result_or.hpp>
+#include <result/result_of.hpp>
 
-TEST_CASE("check ok result-or") {
-  const res::ResultOr<int> res = 32;
+TEST_CASE("check ok result-of") {
+  const res::ResultOf<int> res = 32;
   REQUIRE(res.is_ok());
   REQUIRE_FALSE(res.is_err());
 }
 
-TEST_CASE("check error result-or") {
-  const res::ResultOr<int> res = res::Err("unknown error");
+TEST_CASE("check error result-of") {
+  const res::ResultOf<int> res = res::Err("unknown error");
   REQUIRE(res.is_err());
   REQUIRE_FALSE(res.is_ok());
 }
 
-TEST_CASE("uninitialized result-or contains error") {
-  const res::ResultOr<int> res;
+TEST_CASE("uninitialized result-of contains error") {
+  const res::ResultOf<int> res;
   REQUIRE(res.is_err());
 }
 
-TEST_CASE("call `unwrap` on ok result-or") {
-  const res::ResultOr<int> res = 32;
+TEST_CASE("call `unwrap` on ok result-of") {
+  const res::ResultOf<int> res = 32;
   REQUIRE(res.is_ok());
   REQUIRE(res.unwrap() == 32);
 }
 
-TEST_CASE("call `unwrap` on error result-or") {
-  const res::ResultOr<int> res = res::Err("unknown error");
+TEST_CASE("call `unwrap` on error result-of") {
+  const res::ResultOf<int> res = res::Err("unknown error");
   REQUIRE(res.is_err());
   REQUIRE_THROWS(res.unwrap());
 }
 
-TEST_CASE("call `unwrap_err` on error result-or") {
+TEST_CASE("call `unwrap_err` on error result-of") {
   const std::string err_msg = "unknown error";
-  const res::ResultOr<int> res = res::Err(err_msg);
+  const res::ResultOf<int> res = res::Err(err_msg);
   REQUIRE(res.is_err());
   REQUIRE(res.unwrap_err() == err_msg);
 }
 
-TEST_CASE("call `unwrap_err` on ok result-or") {
-  const res::ResultOr<int> res = 32;
+TEST_CASE("call `unwrap_err` on ok result-of") {
+  const res::ResultOf<int> res = 32;
   REQUIRE(res.is_ok());
   REQUIRE_THROWS(res.unwrap_err());
 }
 
-TEST_CASE("check rewriting result-or") {
-  res::ResultOr<int> res = 32;
+TEST_CASE("check rewriting result-of") {
+  res::ResultOf<int> res = 32;
   REQUIRE(res.is_ok());
   REQUIRE(res.unwrap() == 32);
   std::string err_msg = "unknown error";
@@ -64,24 +64,24 @@ TEST_CASE("check rewriting result-or") {
 }
 
 namespace {
-res::ResultOr<int> foo(bool is_ok) {
+res::ResultOf<int> foo(bool is_ok) {
   if (is_ok) return 32;
   return res::Err("unknown error");
 }
 }  // namespace
 
-TEST_CASE("get result-or from function returning ok") {
+TEST_CASE("get result-of from function returning ok") {
   const auto res = foo(true);
   REQUIRE(res.is_ok());
 }
 
-TEST_CASE("get result-or from function returning error") {
+TEST_CASE("get result-of from function returning error") {
   const auto res = foo(false);
   REQUIRE(res.is_err());
 }
 
-TEST_CASE("check if ok result-or is preserved outside the scope") {
-  res::ResultOr<int> res;
+TEST_CASE("check if ok result-of is preserved outside the scope") {
+  res::ResultOf<int> res;
   {
     res = 32;
     REQUIRE(res.is_ok());
@@ -91,8 +91,8 @@ TEST_CASE("check if ok result-or is preserved outside the scope") {
   REQUIRE(res.unwrap() == 32);
 }
 
-TEST_CASE("check if error result-or is preserved outside the scope") {
-  res::ResultOr<int> res;
+TEST_CASE("check if error result-of is preserved outside the scope") {
+  res::ResultOf<int> res;
   {
     res = res::Err("unknown error");
     REQUIRE(res.is_err());
@@ -102,13 +102,13 @@ TEST_CASE("check if error result-or is preserved outside the scope") {
   REQUIRE(res.unwrap_err() == std::string("unknown error"));
 }
 
-TEST_CASE("cast result-or into result") {
-  res::ResultOr<int> src;
-  SECTION("from ok result-or") {
+TEST_CASE("cast result-of into result") {
+  res::ResultOf<int> src;
+  SECTION("from ok result-of") {
     res::Result res = src = 32;
     CHECK(res.is_ok());
   }
-  SECTION("from error result-or") {
+  SECTION("from error result-of") {
     res::Result res = src = res::Err("unknown error");
     CHECK(res.is_err());
     if (res.is_err()) CHECK(res.unwrap_err() == src.unwrap_err());
@@ -122,22 +122,22 @@ struct Int {
 };
 }  // namespace
 
-TEST_CASE("cast result-or into other result-or with different type") {
-  res::ResultOr<int> res;
-  SECTION("from ok result-or") {
-    res::ResultOr<Int> src = Int{32};
+TEST_CASE("cast result-of into other result-of with different type") {
+  res::ResultOf<int> res;
+  SECTION("from ok result-of") {
+    res::ResultOf<Int> src = Int{32};
     SECTION("using `as()` function") { res = src.as<int>(); }
     SECTION("using explicit cast") {
-      res = static_cast<res::ResultOr<int>>(src);
+      res = static_cast<res::ResultOf<int>>(src);
     }
     CHECK(res.is_ok());
     if (res.is_ok()) CHECK(res.unwrap() == src.unwrap().data);
   }
-  SECTION("from error result-or") {
-    res::ResultOr<Int> src = res::Err("unknown error");
+  SECTION("from error result-of") {
+    res::ResultOf<Int> src = res::Err("unknown error");
     SECTION("using `as()` function") { res = src.as<int>(); }
     SECTION("using explicit cast") {
-      res = static_cast<res::ResultOr<int>>(src);
+      res = static_cast<res::ResultOf<int>>(src);
     }
     CHECK(res.is_err());
     if (res.is_err()) CHECK(res.unwrap_err() == src.unwrap_err());


### PR DESCRIPTION
Simply rename `res::ResultOr` into `res::ResultOf`.

Reason: `res::ResultOf` is a container of `T` data so it's "result of T", instead of "result or T". Different from `absl::StatusOr` in which we could directly extract `absl::Status` from `absl::StatusOr`, hence it's "status or T".