### PR TITLE
Separate Build and Test Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: build
 on:
   workflow_dispatch:
   push:
-    branches: ['**']
 jobs:
   release:
     runs-on: ubuntu-22.04
@@ -20,56 +19,3 @@ jobs:
 
       - name: Build targets
         run: cmake --build build
-
-  test:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout this repository
-        uses: actions/checkout@v2.5.0
-        with:
-          fetch-depth: 0
-
-      - name: Install LLVM and Ninja
-        run: sudo apt install llvm ninja-build
-
-      - name: Install cmake-format
-        run: pip3 install cmake-format
-
-      - name: Configure CMake
-        run: cmake . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G Ninja -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS='-Werror'
-
-      - name: Check code formatting
-        run: cmake --build build --target check-format
-
-      - name: Build targets
-        run: cmake --build build
-
-      - name: Run tests
-        run: ctest --verbose --test-dir build --no-compress-output -T Test || true
-
-      - name: Download Testspace client
-        run: curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C build
-
-      - name: Configure Testspace client
-        working-directory: build
-        run: |
-          ./testspace config url ${{ secrets.TESTSPACE_URL }}
-          ./testspace config project ${{ secrets.TESTSPACE_PROJECT }}
-          ./testspace config space ${{ github.ref_name }}
-
-      - name: Send test result to Testspace
-        working-directory: build
-        run: ./testspace [Tests]"Testing/*/Test.xml"
-
-      - name: Install gcovr
-        run: pip3 install gcovr
-
-      - name: Generate code coverage info
-        working-directory: build
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: gcovr -r .. --gcov-executable 'llvm-cov gcov' --exclude-directories _deps -e _deps --coveralls coverage.json
-
-      - name: Send code coverage info to Coveralls
-        working-directory: build
-        run: curl -v -F json_file=@coverage.json https://coveralls.io/api/v1/jobs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,16 +4,16 @@ on:
   push:
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2.5.0
+        uses: actions/checkout@v3.2.0
 
-      - name: Install LLVM and Ninja
-        run: sudo apt install llvm ninja-build
+      - name: Install Ninja
+        run: sudo apt install ninja-build
 
       - name: Configure CMake
-        run: cmake . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G Ninja
+        run: cmake . -B build -G Ninja
 
       - name: Build targets
         run: cmake --build build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ jobs:
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v2.5.0
-        with:
-          fetch-depth: 0
 
       - name: Install LLVM and Ninja
         run: sudo apt install llvm ninja-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,30 +3,24 @@ on:
   workflow_dispatch:
   push:
 jobs:
-  test:
-    runs-on: ubuntu-22.04
+  test-unit-tests:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2.5.0
+        uses: actions/checkout@v3.2.0
         with:
           fetch-depth: 0
 
       - name: Install LLVM and Ninja
         run: sudo apt install llvm ninja-build
 
-      - name: Install cmake-format
-        run: pip3 install cmake-format
-
       - name: Configure CMake
         run: cmake . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G Ninja -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS='-Werror'
-
-      - name: Check code formatting
-        run: cmake --build build --target check-format
 
       - name: Build targets
         run: cmake --build build
 
-      - name: Run tests
+      - name: Run unit tests
         run: ctest --verbose --test-dir build --no-compress-output -T Test || true
 
       - name: Download Testspace client
@@ -55,3 +49,22 @@ jobs:
       - name: Send code coverage info to Coveralls
         working-directory: build
         run: curl -v -F json_file=@coverage.json https://coveralls.io/api/v1/jobs
+
+  test-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v3.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Install cmake-format
+        run: pip3 install cmake-format
+
+      - name: Configure CMake
+        run: cmake . -B build
+
+      - name: Check code formatting
+        run: |
+          cmake --build build --target format
+          cmake --build build --target check-format

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,14 +41,12 @@ jobs:
         run: pip3 install gcovr
 
       - name: Generate code coverage info
-        working-directory: build
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: gcovr -r .. --gcov-executable 'llvm-cov gcov' --exclude-directories _deps -e _deps --coveralls coverage.json
+        run: gcovr --gcov-executable 'llvm-cov gcov' -e 'build/*' --coveralls build/coverage.json
 
       - name: Send code coverage info to Coveralls
-        working-directory: build
-        run: curl -v -F json_file=@coverage.json https://coveralls.io/api/v1/jobs
+        run: curl -v -F json_file=@build/coverage.json https://coveralls.io/api/v1/jobs
 
   test-formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+name: test
+on:
+  workflow_dispatch:
+  push:
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2.5.0
+        with:
+          fetch-depth: 0
+
+      - name: Install LLVM and Ninja
+        run: sudo apt install llvm ninja-build
+
+      - name: Install cmake-format
+        run: pip3 install cmake-format
+
+      - name: Configure CMake
+        run: cmake . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G Ninja -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS='-Werror'
+
+      - name: Check code formatting
+        run: cmake --build build --target check-format
+
+      - name: Build targets
+        run: cmake --build build
+
+      - name: Run tests
+        run: ctest --verbose --test-dir build --no-compress-output -T Test || true
+
+      - name: Download Testspace client
+        run: curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C build
+
+      - name: Configure Testspace client
+        working-directory: build
+        run: |
+          ./testspace config url ${{ secrets.TESTSPACE_URL }}
+          ./testspace config project ${{ secrets.TESTSPACE_PROJECT }}
+          ./testspace config space ${{ github.ref_name }}
+
+      - name: Send test result to Testspace
+        working-directory: build
+        run: ./testspace [Tests]"Testing/*/Test.xml"
+
+      - name: Install gcovr
+        run: pip3 install gcovr
+
+      - name: Generate code coverage info
+        working-directory: build
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: gcovr -r .. --gcov-executable 'llvm-cov gcov' --exclude-directories _deps -e _deps --coveralls coverage.json
+
+      - name: Send code coverage info to Coveralls
+        working-directory: build
+        run: curl -v -F json_file=@coverage.json https://coveralls.io/api/v1/jobs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         run: sudo apt install llvm ninja-build
 
       - name: Configure CMake
-        run: cmake . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G Ninja -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS='-Werror'
+        run: cmake . -B build -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_TESTING=ON
 
       - name: Build targets
         run: cmake --build build
@@ -46,7 +46,24 @@ jobs:
       - name: Send code coverage info to Coveralls
         run: curl -v -F json_file=@build/coverage.json https://coveralls.io/api/v1/jobs
 
-  test-formatting:
+  test-warning-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v3.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Install Ninja
+        run: sudo apt install ninja-build
+
+      - name: Configure CMake
+        run: cmake . -B build -G Ninja -DCMAKE_CXX_FLAGS='-Werror' -DBUILD_TESTING=ON
+
+      - name: Build targets
+        run: cmake --build build
+
+  test-formatting-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,6 @@ jobs:
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v3.2.0
-        with:
-          fetch-depth: 0
 
       - name: Install LLVM and Ninja
         run: sudo apt install llvm ninja-build
@@ -51,8 +49,6 @@ jobs:
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v3.2.0
-        with:
-          fetch-depth: 0
 
       - name: Install Ninja
         run: sudo apt install ninja-build
@@ -68,8 +64,6 @@ jobs:
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v3.2.0
-        with:
-          fetch-depth: 0
 
       - name: Install cmake-format
         run: pip3 install cmake-format

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
 jobs:
-  test-unit-tests:
+  unit-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
@@ -44,7 +44,7 @@ jobs:
       - name: Send code coverage info to Coveralls
         run: curl -v -F json_file=@build/coverage.json https://coveralls.io/api/v1/jobs
 
-  test-warning-check:
+  check-warning:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
@@ -59,7 +59,7 @@ jobs:
       - name: Build targets
         run: cmake --build build
 
-  test-formatting-check:
+  check-formatting:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,15 +27,13 @@ jobs:
         run: curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C build
 
       - name: Configure Testspace client
-        working-directory: build
         run: |
-          ./testspace config url ${{ secrets.TESTSPACE_URL }}
-          ./testspace config project ${{ secrets.TESTSPACE_PROJECT }}
-          ./testspace config space ${{ github.ref_name }}
+          build/testspace config url ${{ secrets.TESTSPACE_URL }}
+          build/testspace config project ${{ secrets.TESTSPACE_PROJECT }}
+          build/testspace config space ${{ github.ref_name }}
 
       - name: Send test result to Testspace
-        working-directory: build
-        run: ./testspace [Tests]"Testing/*/Test.xml"
+        run: build/testspace [Tests]"build/Testing/*/Test.xml"
 
       - name: Install gcovr
         run: pip3 install gcovr

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wnon-virtual-dtor -Wpedantic")
 
 project(result)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Result
 
 [![build status](https://img.shields.io/github/actions/workflow/status/threeal/result/build.yml?branch=main)](https://github.com/threeal/result/actions/workflows/build.yml)
-[![test result](https://img.shields.io/testspace/pass-ratio/threeal/threeal:result/main)](https://threeal.testspace.com/projects/threeal:result)
+[![test status](https://img.shields.io/github/actions/workflow/status/threeal/result/test.yml?label=test&branch=main)](https://github.com/threeal/result/actions/workflows/test.yml)
+[![test results](https://img.shields.io/testspace/pass-ratio/threeal/threeal:result/main)](https://threeal.testspace.com/projects/threeal:result)
 [![code coverage](https://img.shields.io/coveralls/github/threeal/result/main)](https://coveralls.io/github/threeal/result)
 
 A simple C++ alternative of [Abseil Status](https://abseil.io/docs/cpp/guides/status).


### PR DESCRIPTION
- Separate `test` job from `build.yml` workflow into `test.yml` workflow.
- Separate test workflow into 3 different jobs: `unit-tests`, `check-warning`, and `check-formatting`.
- Audit [Checkout](https://github.com/actions/checkout) actions to use latest version and without `fetch-depth` option.
- Remove `-WShadow` warning option in the compiler flags.
- Add test badge in the `README.md`.