### PR TITLE
Add MSVC Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,8 @@ jobs:
       - name: Checkout this repository
         uses: actions/checkout@v3.2.0
 
-      - name: Install Ninja
-        run: sudo apt install ninja-build
-
       - name: Configure CMake
-        run: cmake . -B build -G Ninja
+        run: cmake . -B build
 
       - name: Build targets
         run: cmake --build build
@@ -24,11 +21,8 @@ jobs:
       - name: Checkout this repository
         uses: actions/checkout@v3.2.0
 
-      - name: Install Ninja
-        run: choco install -y ninja
-
       - name: Configure CMake
-        run: cmake . -B build -G Ninja
+        run: cmake . -B build
 
       - name: Build targets
         run: cmake --build build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,3 +17,18 @@ jobs:
 
       - name: Build targets
         run: cmake --build build
+
+  release-msvc:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v3.2.0
+
+      - name: Install Ninja
+        run: choco install -y ninja
+
+      - name: Configure CMake
+        run: cmake . -B build -G Ninja
+
+      - name: Build targets
+        run: cmake --build build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,21 @@ jobs:
       - name: Build targets
         run: cmake --build build
 
+  check-warning-msvc:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v3.2.0
+
+      - name: Install Ninja
+        run: choco install -y ninja
+
+      - name: Configure CMake
+        run: cmake . -B build -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_CXX_FLAGS=/WX -DBUILD_TESTING=ON
+
+      - name: Build targets
+        run: cmake --build build
+
   check-formatting:
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,11 @@ if(BUILD_TESTING)
 
   cpmaddpackage("gh:catchorg/Catch2@3.2.0")
   include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
+
+  if(NOT MSVC)
+    # set coverage flags (not supported in MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
+  endif()
 
   add_executable(result_test test/result_test.cpp test/result_of_test.cpp)
   target_link_libraries(result_test PRIVATE result Catch2::Catch2WithMain)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,14 @@
 cmake_minimum_required(VERSION 3.14)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wnon-virtual-dtor -Wpedantic")
-
 project(result)
+
+set(CMAKE_CXX_STANDARD 17)
+
+if(MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /W4 /w14640 /EHsc")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wnon-virtual-dtor -Wpedantic")
+endif()
 
 include(cmake/CPM.cmake)
 cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")


### PR DESCRIPTION
- Add build release and check warning jobs that runs on Windows using [MSVC](https://visualstudio.microsoft.com/vs/features/cplusplus/).
- Remove Ninja generator in build release jobs since release doesn't actually build anything.
- Add supported compiler flags for warning in MSVC
- Remove compiler flags for generating coverage if using MSVC.