### PR TITLE
Use Gcovr Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
         run: testspace [Tests]"build/Testing/*/Test.xml"
 
       - name: Generate and send code coverage report to Coveralls
+        if: steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failure'
         uses: threeal/gcovr-action@v0.1.0
         with:
           gcov-executable: llvm-cov gcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Setup Testspace client
         id: setup_testspace
-        if: steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failed'
+        if: steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failure'
         uses: testspace-com/setup-testspace@v1.0.5
         with:
           domain: ${{github.repository_owner}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,16 +33,13 @@ jobs:
         if: steps.setup_testspace.outcome == 'success'
         run: testspace [Tests]"build/Testing/*/Test.xml"
 
-      - name: Install gcovr
-        run: pip3 install gcovr
-
-      - name: Generate code coverage info
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: gcovr --gcov-executable 'llvm-cov gcov' -e 'build/*' --coveralls build/coverage.json
-
-      - name: Send code coverage info to Coveralls
-        run: curl -v -F json_file=@build/coverage.json https://coveralls.io/api/v1/jobs
+      - name: Generate and send code coverage report to Coveralls
+        uses: threeal/gcovr-action@v0.1.0
+        with:
+          gcov-executable: llvm-cov gcov
+          exclude: build/*
+          coveralls-send: true
+          coveralls-repo-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
   check-warning:
     runs-on: ubuntu-latest

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Alfi Maulana
+Copyright (c) 2022-2023 Alfi Maulana
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- Use [Gcovr Action](https://github.com/marketplace/actions/gcovr-action) to simplify [gcovr](https://gcovr.com/en/stable/) setup and call for generating code coverage report.
- Rename license file into `LICENSE` and update years to 2023.
- Always run generate code coverage step even if test is failed.