### PR TITLE
Fix Coveralls Send

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           gcov-executable: llvm-cov gcov
           exclude: build/*
           coveralls-send: true
-          coveralls-repo-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   check-warning:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix the workflow does not sending coverage report to [Coveralls](https://coveralls.io/) because of unset `github-token` action input.