### PR TITLE
Docs: Fix Missing OSI Logo

### DIFF
--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,7 +1,7 @@
 License
 =======
 
-.. image:: https://opensource.org/files/OSIApproved_1.png
+.. image:: https://opensource.org/wp-content/uploads/2022/10/osi-badge-dark.svg
    :width: 150
    :align: right
    :target: https://opensource.org/licenses


### PR DESCRIPTION
Fix missing [Open Source Initiative (OSI) approved license](https://opensource.org/licenses/) logo in the license page of the documentation.