### PR TITLE
CMake Filter Content for Development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,24 +10,26 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wnon-virtual-dtor -Wpedantic")
 endif()
 
-include(cmake/CPM.cmake)
-cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
-
 add_library(result INTERFACE)
 target_include_directories(result INTERFACE include)
 
-if(BUILD_TESTING AND CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  enable_testing()
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  include(cmake/CPM.cmake)
+  cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
 
-  cpmaddpackage("gh:catchorg/Catch2@3.2.0")
-  include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
+  if(BUILD_TESTING)
+    enable_testing()
 
-  if(NOT MSVC)
-    # set coverage flags (not supported in MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
+    cpmaddpackage("gh:catchorg/Catch2@3.2.0")
+    include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
+
+    if(NOT MSVC)
+      # set coverage flags (not supported in MSVC)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
+    endif()
+
+    add_executable(result_test test/code_test.cpp test/err_test.cpp test/result_test.cpp test/result_of_test.cpp)
+    target_link_libraries(result_test PRIVATE result Catch2::Catch2WithMain)
+    catch_discover_tests(result_test)
   endif()
-
-  add_executable(result_test test/code_test.cpp test/err_test.cpp test/result_test.cpp test/result_of_test.cpp)
-  target_link_libraries(result_test PRIVATE result Catch2::Catch2WithMain)
-  catch_discover_tests(result_test)
 endif()


### PR DESCRIPTION
Filter these content in CMake to be only available if being build in local development scope:
- Inclusion of [Format.cmake](https://github.com/TheLartians/Format.cmake) dependency.
- Inclusion of [Catch2](https://github.com/catchorg/Catch2) dependency.
- Test build.