### PR TITLE
Modify GitHub Workflow Trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: build
 on:
   workflow_dispatch:
+  pull_request:
   push:
+    branches: [latest, main]
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: test
 on:
   workflow_dispatch:
+  pull_request:
   push:
+    branches: [latest, main]
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Modify the GitHub workflow to be triggered only on pull request event and push event. The push event only triggers if the target branch is either `latest` or `main`.