### PR TITLE
Simplify Build Docs Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,6 @@ jobs:
           sudo apt-get install -y doxygen
           pip3 install -r docs/requirements.txt
 
-      - name: Generate Doxygen API documentation
-        working-directory: docs
-        run: doxygen
-
       - name: Build documentation with Sphinx
         run: sphinx-build -b html docs build/html -W --keep-going
 


### PR DESCRIPTION
Simplify the documentation build workflow by removing the step that generates API documentation with [Doxygen](https://www.doxygen.nl/).