### PR TITLE
Update Format.cmake to Support Auto Installation of cmake-format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,9 +73,6 @@ jobs:
       - name: Checkout this repository
         uses: actions/checkout@v3.5.3
 
-      - name: Install cmake-format
-        run: pip3 install cmake-format
-
       - name: Configure and check formatting
         uses: threeal/cmake-action@v1.1.0
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(result INTERFACE include)
 target_link_libraries(result INTERFACE error)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
+  cpmaddpackage("gh:threeal/Format.cmake#auto-install-cmake-format")
 
   if(BUILD_TESTING)
     enable_testing()


### PR DESCRIPTION
Updated the declaration of [Format.cmake](https://github.com/TheLartians/Format.cmake) in the `CMakeLists.txt` file to use the [`auto-install-cmake-format`](https://github.com/threeal/Format.cmake/tree/auto-install-cmake-format) branch. This branch includes enhancements that enable automatic installation of [cmake-format](https://cmake-format.readthedocs.io/en/latest/).