### PR TITLE
Exclude `latest` Branch from Pull Request Workflows Trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: build
 on:
   workflow_dispatch:
   pull_request:
+    branches: ['*', '!latest']
   push:
     branches: [latest, main]
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: test
 on:
   workflow_dispatch:
   pull_request:
+    branches: ['*', '!latest']
   push:
     branches: [latest, main]
 jobs:


### PR DESCRIPTION
Update the pull request events to trigger the `build.yml` and `test.yml` workflows only when the pull request targets branches other than the `latest` branch.