### PR TITLE
Remove the `latest` Branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,8 @@ name: build
 on:
   workflow_dispatch:
   pull_request:
-    branches: ['*', '!latest']
   push:
-    branches: [latest, main]
+    branches: [main]
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,8 @@ name: test
 on:
   workflow_dispatch:
   pull_request:
-    branches: ['*', '!latest']
   push:
-    branches: [latest, main]
+    branches: [main]
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request removed the `latest` branch by removing that branch from affecting triggers in the CI workflow. It closes #72.