### PR TITLE
Remove Test Result Submission to Testspace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,18 +19,6 @@ jobs:
           cxx-compiler: clang++
           args: -DBUILD_TESTING=ON
           run-test: true
-          test-args: --no-compress-output -T Test
-
-      - name: Setup Testspace client
-        id: setup_testspace
-        if: steps.cmake_action.outcome == 'success' || steps.cmake_action.outcome == 'failure'
-        uses: testspace-com/setup-testspace@v1.0.6
-        with:
-          domain: ${{github.repository_owner}}
-
-      - name: Send test result to Testspace
-        if: steps.setup_testspace.outcome == 'success'
-        run: testspace [Tests]"build/Testing/*/Test.xml"
 
       - name: Generate and send code coverage report to Coveralls
         if: steps.cmake_action.outcome == 'success' || steps.cmake_action.outcome == 'failure'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![build status](https://img.shields.io/github/actions/workflow/status/threeal/result/build.yml?branch=main)](https://github.com/threeal/result/actions/workflows/build.yml)
 [![test status](https://img.shields.io/github/actions/workflow/status/threeal/result/test.yml?label=test&branch=main)](https://github.com/threeal/result/actions/workflows/test.yml)
-[![test results](https://img.shields.io/testspace/pass-ratio/threeal/threeal:result/main)](https://threeal.testspace.com/projects/threeal:result)
 [![code coverage](https://img.shields.io/coveralls/github/threeal/result/main)](https://coveralls.io/github/threeal/result)
 
 A simple C++ implementation of [Rust Result](https://doc.rust-lang.org/std/result), an alternative to [Abseil Status](https://abseil.io/docs/cpp/guides/status).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Result
 ======
 
-|build_status_badge|_ |test_status_badge|_ |test_results_badge|_ |code_coverage_badge|_
+|build_status_badge|_ |test_status_badge|_ |code_coverage_badge|_
 
 A simple C++ implementation of `Rust Result`_, an alternative to `Abseil Status`_.
 
@@ -16,9 +16,6 @@ A simple C++ implementation of `Rust Result`_, an alternative to `Abseil Status`
 
 .. |test_status_badge| image:: https://img.shields.io/github/actions/workflow/status/threeal/result/test.yml?label=test&branch=main
 .. _test_status_badge: https://github.com/threeal/result/actions/workflows/test.yml
-
-.. |test_results_badge| image:: https://img.shields.io/testspace/pass-ratio/threeal/threeal:result/main
-.. _test_results_badge: https://threeal.testspace.com/projects/threeal:result
 
 .. |code_coverage_badge| image:: https://img.shields.io/coveralls/github/threeal/result/main
 .. _code_coverage_badge: https://coveralls.io/github/threeal/result


### PR DESCRIPTION
This pull request resolves #76 by introducing the following changes:
- Removes steps for sending test result to Testspace in the `unit-tests` job of `test.yml` workflow.
- Removes the test result badge from the `README.md` file and the documentation.