### PR TITLE
Bump Copyright Year to 2024

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2023 Alfi Maulana
+Copyright (c) 2022-2024 Alfi Maulana
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ A simple C++ implementation of [Rust Result](https://doc.rust-lang.org/std/resul
 
 This project is licensed under the terms of the [MIT License](./LICENSE).
 
-Copyright © 2022-2023 [Alfi Maulana](https://github.com/threeal)
+Copyright © 2022-2024 [Alfi Maulana](https://github.com/threeal)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 import os, subprocess
 
 project = 'result'
-copyright = '2022-2023, Alfi Maulana'
+copyright = '2022-2024, Alfi Maulana'
 author = 'Alfi Maulana'
 
 extensions = ['breathe']

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -8,7 +8,7 @@ License
 
 This project is licensed under the terms of the `MIT License`_.
 
-Copyright © 2022-2023 `Alfi Maulana`_
+Copyright © 2022-2024 `Alfi Maulana`_
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request simply bumps the copyright year in all files to be `2022-2024`.