### PR TITLE
Wrong Gcov Executable in Test Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Check coverage
         uses: threeal/gcovr-action@v1.0.0
         with:
-          gcov-executable: llvm-cov gcov
           excludes: build/*
           fail-under-line: 99
 


### PR DESCRIPTION
This pull request resolves #90 by removing the input for setting a Gcov executable in the check coverage step of the `test` workflow.