### PR TITLE
Bump Catch2 to Version 3.5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   if(BUILD_TESTING)
     enable_testing()
 
-    cpmaddpackage(gh:catchorg/Catch2@3.5.1)
+    cpmaddpackage(gh:catchorg/Catch2@3.5.2)
     include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
     if(NOT MSVC)


### PR DESCRIPTION
This pull request simply bumps Catch2 to [version 3.5.2](https://github.com/catchorg/Catch2/releases/tag/v3.5.2).