### PR TITLE
Remove Badges from Readme and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Result
 
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/result/build.yml?branch=main)](https://github.com/threeal/result/actions/workflows/build.yml)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/result/test.yml?label=test&branch=main)](https://github.com/threeal/result/actions/workflows/test.yml)
-
 A simple C++ implementation of [Rust Result](https://doc.rust-lang.org/std/result), an alternative to [Abseil Status](https://abseil.io/docs/cpp/guides/status).
 
 ## License

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,6 @@
 Result
 ======
 
-|build_status_badge|_ |test_status_badge|_
-
 A simple C++ implementation of `Rust Result`_, an alternative to `Abseil Status`_.
 
 .. toctree::
@@ -10,12 +8,6 @@ A simple C++ implementation of `Rust Result`_, an alternative to `Abseil Status`
 
    api_docs.rst
    license.rst
-
-.. |build_status_badge| image:: https://img.shields.io/github/actions/workflow/status/threeal/result/build.yml?branch=main
-.. _build_status_badge: https://github.com/threeal/result/actions/workflows/build.yml
-
-.. |test_status_badge| image:: https://img.shields.io/github/actions/workflow/status/threeal/result/test.yml?label=test&branch=main
-.. _test_status_badge: https://github.com/threeal/result/actions/workflows/test.yml
 
 .. _Abseil Status: https://abseil.io/docs/cpp/guides/status
 .. _Rust Result: https://doc.rust-lang.org/std/result


### PR DESCRIPTION
This pull request resolves #99 by removing badges from the `README.md` file and the documentation.