### PR TITLE
Utilize CheckWarning.cmake Module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,32 +24,6 @@ jobs:
           excludes: build/*
           fail-under-line: 99
 
-  check-warning:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout this repository
-        uses: actions/checkout@v4.1.6
-
-      - name: Configure and build this project
-        uses: threeal/cmake-action@v1.3.0
-        with:
-          cxx-flags: -Werror
-          args: -DBUILD_TESTING=ON
-          run-build: true
-
-  check-warning-msvc:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout this repository
-        uses: actions/checkout@v4.1.6
-
-      - name: Configure and build this project
-        uses: threeal/cmake-action@v1.3.0
-        with:
-          cxx-flags: /WX
-          args: -DBUILD_TESTING=ON
-          run-build: true
-
   check-formatting:
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,13 @@ project(result)
 
 set(CMAKE_CXX_STANDARD 17)
 
-if(MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /W4 /w14640 /EHsc")
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wnon-virtual-dtor -Wpedantic")
-endif()
-
 include(cmake/CPM.cmake)
+
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
+  cpmaddpackage(gh:threeal/CheckWarning.cmake@2.1.1)
+  include(${CheckWarning_SOURCE_DIR}/cmake/CheckWarning.cmake)
+  add_check_warning()
+endif()
 
 cpmaddpackage(
   NAME error


### PR DESCRIPTION
This pull request resolves #89 by utilizing [CheckWarning.cmake](https://github.com/threeal/CheckWarning.cmake/) to enable warning flags in this project, replacing direct settings to the `CMAKE_CXX_FLAGS` variable and removing check warning jobs from the `test` workflow.