### PR TITLE
Utilize Version 1.0.0 of Errors C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,15 +12,11 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
   add_check_warning()
 endif()
 
-cpmaddpackage(
-  NAME error
-  GIT_TAG f9b39f8
-  GITHUB_REPOSITORY threeal/cpp
-  SOURCE_SUBDIR error)
+cpmaddpackage(gh:threeal/errors-cpp@1.0.0)
 
 add_library(result INTERFACE)
 target_include_directories(result INTERFACE include)
-target_link_libraries(result INTERFACE error)
+target_link_libraries(result INTERFACE errors)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   cpmaddpackage(

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <error/error.hpp>
+#include <errors/error.hpp>
 #include <variant>
 
 #include "ok.hpp"
@@ -39,7 +39,7 @@ namespace result {
 template <typename T = Ok>
 class [[nodiscard]] Result {
  private:
-  std::variant<T, error::Error> data;
+  std::variant<T, errors::Error> data;
   bool data_is_err;
 
  public:
@@ -78,14 +78,14 @@ class [[nodiscard]] Result {
    * @param err The error.
    *
    * @code{.cpp}
-   * result::Result<int> res = error::Error("undefined error");
+   * result::Result<int> res = errors::make("undefined error");
    * assert(res.is_err());
    *
    * // Print "undefined error".
    * std::cout << res.unwrap_err().what() << std::endl;
    * @endcode
    */
-  Result(const error::Error& err);
+  Result(const errors::Error& err);
 
   /**
    * @brief Explicitly converts the result into another result with a different
@@ -102,7 +102,7 @@ class [[nodiscard]] Result {
    * using IntRes = result::Result<int>;
    *
    * result::Result<double> square_root(double val) {
-   *   if (value < 0) return error::Error("value must be positive");
+   *   if (value < 0) return errors::make("value must be positive");
    *   return std::sqrt(value);
    * }
    *
@@ -136,7 +136,7 @@ class [[nodiscard]] Result {
    *
    * @code{.cpp}
    * result::Result<double> square_root(double val) {
-   *   if (value < 0) return error::Error("value must be positive");
+   *   if (value < 0) return errors::make("value must be positive");
    *   return std::sqrt(value);
    * }
    *
@@ -173,12 +173,12 @@ class [[nodiscard]] Result {
   /**
    * @brief Gets the value from the result.
    * @return A constant reference to the stored value.
-   * @throws error::Error If the result does not contain a value.
+   * @throws errors::Error If the result does not contain a value.
    *
    * This function retrieves the value stored in the result object. If the
    * result contains a value, it returns a constant reference to the value. If
    * the result does not contain a value, it throws an exception of type
-   * `error::Error`.
+   * `errors::Error`.
    *
    * @code{.cpp}
    * result::Result<int> res = 200;
@@ -186,9 +186,9 @@ class [[nodiscard]] Result {
    * // Print "200".
    * std::cout << res.unwrap() << std::endl;
    *
-   * res = error::Error("undefined error");
+   * res = errors::make("undefined error");
    *
-   * // Throws `error::Error`.
+   * // Throws `errors::Error`.
    * // std::cout << res.unwrap() << std::endl;
    * @endcode
    */
@@ -197,26 +197,26 @@ class [[nodiscard]] Result {
   /**
    * @brief Gets the error from the result.
    * @return A constant reference to the stored error.
-   * @throws error::Error If the result does not contain an error.
+   * @throws errors::Error If the result does not contain an error.
    *
    * This function retrieves the error stored in the result object. If the
    * result contains an error, it returns a constant reference to the error. If
    * the result does not contain an error, it throws an exception of type
-   * `error::Error`.
+   * `errors::Error`.
    *
    * @code{.cpp}
-   * result::Result<int> res = error::Error("undefined error");
+   * result::Result<int> res = errors::make("undefined error");
    *
    * // Print "undefined error".
    * std::cout << res.unwrap_err().what() << std::endl;
    *
    * res = 200;
    *
-   * // Throws `error::Error`.
+   * // Throws `errors::Error`.
    * // std::cout << res.unwrap_err().what() << std::endl;
    * @endcode
    */
-  const error::Error& unwrap_err() const;
+  const errors::Error& unwrap_err() const;
 };
 
 }  // namespace result

--- a/include/result/result.ipp
+++ b/include/result/result.ipp
@@ -1,38 +1,38 @@
 namespace result {
 
 template <typename T>
-Result<T>::Result() : Result(error::Error("the result is uninitialized")) {}
+Result<T>::Result() : Result(errors::make("the result is uninitialized")) {}
 
 template <typename T>
 Result<T>::Result(const T& val) : data(val), data_is_err(false) {}
 
 template <typename T>
-Result<T>::Result(const error::Error& err) : data(err), data_is_err(true) {}
+Result<T>::Result(const errors::Error& err) : data(err), data_is_err(true) {}
 
 template <typename T>
 template <typename U>
 Result<T>::operator Result<U>() const {
-  if (data_is_err) return std::get<error::Error>(data);
+  if (data_is_err) return std::get<errors::Error>(data);
   return static_cast<U>(std::get<T>(data));
 }
 
 template <typename T>
 template <typename U>
 Result<U> Result<T>::as() const {
-  if (data_is_err) return std::get<error::Error>(data);
+  if (data_is_err) return std::get<errors::Error>(data);
   return static_cast<U>(std::get<T>(data));
 }
 
 template <typename T>
 const T& Result<T>::unwrap() const {
-  if (data_is_err) throw error::format("the result contains an error");
+  if (data_is_err) throw errors::make("the result contains an error");
   return std::get<T>(data);
 }
 
 template <typename T>
-const error::Error& Result<T>::unwrap_err() const {
-  if (!data_is_err) throw error::Error("the result contains a value");
-  return std::get<error::Error>(data);
+const errors::Error& Result<T>::unwrap_err() const {
+  if (!data_is_err) throw errors::make("the result contains a value");
+  return std::get<errors::Error>(data);
 }
 
 }  // namespace result

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -6,7 +6,7 @@ TEST_CASE("Result creation") {
   SECTION("Create empty") {
     const result::Result<> res;
     REQUIRE(res.is_err());
-    REQUIRE(res.unwrap_err().message == "the result is uninitialized");
+    REQUIRE(res.unwrap_err().message() == "the result is uninitialized");
   }
 
   SECTION("Create with OK value") {
@@ -21,9 +21,9 @@ TEST_CASE("Result creation") {
   }
 
   SECTION("Create with error") {
-    const result::Result<int> res = error::Error("unknown error");
+    const result::Result<int> res = errors::make("unknown error");
     REQUIRE(res.is_err());
-    REQUIRE(res.unwrap_err().message == "unknown error");
+    REQUIRE(res.unwrap_err().message() == "unknown error");
   }
 }
 
@@ -33,16 +33,16 @@ TEST_CASE("Result data getting") {
 
     SECTION("Get value") { REQUIRE(res.unwrap() == 200); }
 
-    SECTION("Get error") { REQUIRE_THROWS_AS(res.unwrap_err(), error::Error); }
+    SECTION("Get error") { REQUIRE_THROWS_AS(res.unwrap_err(), errors::Error); }
   }
 
   SECTION("From result with error") {
-    const result::Result<int> res = error::Error("unknown error");
+    const result::Result<int> res = errors::make("unknown error");
 
-    SECTION("Get value") { REQUIRE_THROWS_AS(res.unwrap(), error::Error); }
+    SECTION("Get value") { REQUIRE_THROWS_AS(res.unwrap(), errors::Error); }
 
     SECTION("Get error") {
-      REQUIRE(res.unwrap_err().message == "unknown error");
+      REQUIRE(res.unwrap_err().message() == "unknown error");
     }
   }
 }
@@ -54,9 +54,9 @@ TEST_CASE("Result rewriting") {
     REQUIRE(res.unwrap() == 200);
 
     SECTION("Rewrite with error") {
-      res = error::Error("unknown error");
+      res = errors::make("unknown error");
       REQUIRE(res.is_err());
-      REQUIRE(res.unwrap_err().message == "unknown error");
+      REQUIRE(res.unwrap_err().message() == "unknown error");
 
       SECTION("Rewrite again with another value") {
         res = 201;
@@ -67,9 +67,9 @@ TEST_CASE("Result rewriting") {
   }
 
   SECTION("Initialize result with error") {
-    result::Result<int> res = error::Error("unknown error");
+    result::Result<int> res = errors::make("unknown error");
     REQUIRE(res.is_err());
-    REQUIRE(res.unwrap_err().message == "unknown error");
+    REQUIRE(res.unwrap_err().message() == "unknown error");
 
     SECTION("Rewrite with value") {
       res = 200;
@@ -77,9 +77,9 @@ TEST_CASE("Result rewriting") {
       REQUIRE(res.unwrap() == 200);
 
       SECTION("Rewrite again with another error") {
-        res = error::Error("other error");
+        res = errors::make("other error");
         REQUIRE(res.is_err());
-        REQUIRE(res.unwrap_err().message == "other error");
+        REQUIRE(res.unwrap_err().message() == "other error");
       }
     }
   }
@@ -87,7 +87,7 @@ TEST_CASE("Result rewriting") {
 
 TEST_CASE("Result from function getting") {
   const auto square_root = [](double value) -> result::Result<double> {
-    if (value < 0) return error::Error("value must be positive");
+    if (value < 0) return errors::make("value must be positive");
     return std::sqrt(value);
   };
 
@@ -100,7 +100,7 @@ TEST_CASE("Result from function getting") {
   SECTION("From a function returning an error result") {
     const auto res = square_root(-1);
     REQUIRE(res.is_err());
-    REQUIRE(res.unwrap_err().message == "value must be positive");
+    REQUIRE(res.unwrap_err().message() == "value must be positive");
   }
 }
 
@@ -120,7 +120,7 @@ TEST_CASE("Result casting") {
   }
 
   SECTION("Cast result with error") {
-    result::Result<int> src = error::Error("unknown error");
+    result::Result<int> src = errors::make("unknown error");
     result::Result<unsigned int> dst;
 
     SECTION("Using as function") { dst = src.as<unsigned int>(); }
@@ -130,6 +130,6 @@ TEST_CASE("Result casting") {
     }
 
     REQUIRE(dst.is_err());
-    REQUIRE(dst.unwrap_err().message == "unknown error");
+    REQUIRE(dst.unwrap_err().message() == "unknown error");
   }
 }


### PR DESCRIPTION
This pull request resolves #113 by utilizing version 1.0.0 of the Errors C++ package.