### PR TITLE
Add Option to Enable Test Targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         id: cmake_action
         uses: threeal/cmake-action@v1.3.0
         with:
-          args: -DBUILD_TESTING=ON
+          options: RESULT_ENABLE_TESTS=ON
           run-test: true
 
       - name: Check coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,11 @@ project(result)
 
 set(CMAKE_CXX_STANDARD 17)
 
+option(RESULT_ENABLE_TESTS "Enable test targets.")
+
 include(cmake/CPM.cmake)
 
-if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+if(PROJECT_IS_TOP_LEVEL AND RESULT_ENABLE_TESTS)
   cpmaddpackage(gh:threeal/CheckWarning.cmake@2.1.1)
   include(${CheckWarning_SOURCE_DIR}/cmake/CheckWarning.cmake)
   add_check_warning()
@@ -25,7 +27,7 @@ if(PROJECT_IS_TOP_LEVEL)
     OPTIONS "FORMAT_SKIP_CMAKE ON"
   )
 
-  if(BUILD_TESTING)
+  if(RESULT_ENABLE_TESTS)
     enable_testing()
 
     cpmaddpackage(gh:catchorg/Catch2@3.6.0)


### PR DESCRIPTION
This pull request resolves #122 by adding a `RESULT_ENABLE_TESTS` option to enable test targets in the project, replacing the `BUILD_TESTING` variable.