### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v4.1.7
@@ -15,7 +15,7 @@ jobs:
         uses: threeal/cmake-action@v2.0.0
 
   release-msvc:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v4.1.7
@@ -24,7 +24,7 @@ jobs:
         uses: threeal/cmake-action@v2.0.0
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy-pages:
     name: Deploy Pages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       pages: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v4.1.7
@@ -26,7 +26,7 @@ jobs:
           fail-under-line: 99
 
   check-formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
This pull request resolves #132 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.