### PR TITLE
Bump CheckWarning.cmake to Version 3.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(RESULT_ENABLE_TESTS "Enable test targets.")
 include(cmake/CPM.cmake)
 
 if(PROJECT_IS_TOP_LEVEL AND RESULT_ENABLE_TESTS)
-  cpmaddpackage(gh:threeal/CheckWarning.cmake@3.1.0)
+  cpmaddpackage(gh:threeal/CheckWarning.cmake@3.2.0)
   add_check_warning(TREAT_WARNINGS_AS_ERRORS)
 endif()
 


### PR DESCRIPTION
This pull request updates the [CheckWarning.cmake](https://github.com/threeal/CheckWarning.cmake) project used by the sample project in this template to version [3.2.0](https://github.com/threeal/CheckWarning.cmake/releases/tag/v3.2.0).