### PR TITLE
Remove Upload Documentation Step in Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,3 @@ jobs:
 
       - name: Build documentation with Sphinx
         run: sphinx-build -b html docs build/html -W --keep-going
-
-      - name: Upload documentation as artifact
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: html
-          path: build/html


### PR DESCRIPTION
This pull request resolves #157 by removing the "Upload documentation as artifact" step from the Build workflow.