### PR TITLE
Bump Catch2 to Version 3.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(PROJECT_IS_TOP_LEVEL)
   if(RESULT_ENABLE_TESTS)
     enable_testing()
 
-    cpmaddpackage(gh:catchorg/Catch2@3.8.0)
+    cpmaddpackage(gh:catchorg/Catch2@3.9.0)
     include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
     if(NOT MSVC)


### PR DESCRIPTION
This pull request bumps Catch2 to version [3.9.0](https://github.com/catchorg/Catch2/releases/tag/v3.9.0).